### PR TITLE
fix: clear remaining Codacy findings

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,7 +16,7 @@ sys.path.insert(2, str(Path(__file__).parent.parent))
 # -- Project information -----------------------------------------------------
 
 project = "MailThunder"
-copyright = "2020 ~ Now, JE-Chen"
+project_copyright = "2020 ~ Now, JE-Chen"
 author = "JE-Chen"
 
 # -- General configuration ---------------------------------------------------

--- a/je_mail_thunder/utils/package_manager/package_manager_class.py
+++ b/je_mail_thunder/utils/package_manager/package_manager_class.py
@@ -1,15 +1,14 @@
-import re
 from importlib import import_module
 from importlib.util import find_spec
 from inspect import getmembers, isfunction, isbuiltin, isclass
 
 from je_mail_thunder.utils.logging.loggin_instance import mail_thunder_logger
 
-_MODULE_NAME_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$")
-
 
 def _is_safe_module_name(package: str) -> bool:
-    return isinstance(package, str) and bool(_MODULE_NAME_PATTERN.fullmatch(package))
+    if not isinstance(package, str) or not package:
+        return False
+    return all(part.isidentifier() for part in package.split("."))
 
 
 class PackageManager:

--- a/je_mail_thunder/utils/package_manager/package_manager_class.py
+++ b/je_mail_thunder/utils/package_manager/package_manager_class.py
@@ -1,8 +1,15 @@
+import re
 from importlib import import_module
 from importlib.util import find_spec
 from inspect import getmembers, isfunction, isbuiltin, isclass
 
 from je_mail_thunder.utils.logging.loggin_instance import mail_thunder_logger
+
+_MODULE_NAME_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$")
+
+
+def _is_safe_module_name(package: str) -> bool:
+    return isinstance(package, str) and bool(_MODULE_NAME_PATTERN.fullmatch(package))
 
 
 class PackageManager:
@@ -17,9 +24,13 @@ class PackageManager:
         :param package: package to check exists or not
         :return: package if find else None
         """
+        if not _is_safe_module_name(package):
+            mail_thunder_logger.error(
+                f"check_package: rejected non-conforming module name: {package!r}")
+            return None
         if self.installed_package_dict.get(package, None) is None:
             found_spec = find_spec(package)
-            if found_spec is not None:
+            if found_spec is not None and _is_safe_module_name(found_spec.name):
                 try:
                     installed_package = import_module(found_spec.name)
                     self.installed_package_dict.update(

--- a/test/unit_test/test_executor.py
+++ b/test/unit_test/test_executor.py
@@ -1,6 +1,3 @@
-import os
-import types
-
 import pytest
 
 from je_mail_thunder.utils.exception.exceptions import AddCommandException, ExecuteActionException

--- a/test/unit_test/test_get_dir_file_list.py
+++ b/test/unit_test/test_get_dir_file_list.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 import tempfile
 
 from je_mail_thunder.utils.file_process.get_dir_file_list import get_dir_files_as_list

--- a/test/unit_test/test_json_file.py
+++ b/test/unit_test/test_json_file.py
@@ -1,9 +1,6 @@
 import json
 import os
 
-import pytest
-
-from je_mail_thunder.utils.exception.exceptions import JsonActionException
 from je_mail_thunder.utils.json.json_file import read_action_json, write_action_json
 
 TEST_JSON_PATH = "test_action.json"


### PR DESCRIPTION
## Summary
- Validate package names with a strict module-identifier regex before `find_spec` / `import_module` in `PackageManager.check_package` so user-controlled inputs cannot trigger dynamic import of arbitrary modules (Semgrep `non-literal-import`).
- Switch `docs/source/conf.py` to Sphinx's `project_copyright` alias to stop shadowing the `copyright` builtin (Pylint W0622).
- Remove 5 unused imports flagged by Prospector pyflakes across `test_executor.py`, `test_get_dir_file_list.py`, and `test_json_file.py`.

## Test plan
- [x] `pytest` — 55/55 passing locally
- [ ] Codacy issue count drops to 0 on the next scan
- [ ] SonarCloud quality gate stays green